### PR TITLE
Iss74 - Improper truncation of min/max values

### DIFF
--- a/brainsprite.js
+++ b/brainsprite.js
@@ -1,6 +1,6 @@
 function displayFloat (v, nbDecimals) {
   var str = parseFloat(v).toFixed(nbDecimals)
-  return str.indexOf('.') === -1 ? str : str.replace(/0+$/, '')
+  return str.indexOf('.') === -1 ? str + '.' : str.replace(/0+$/, '')
 }
 
 function initBrain (params) {

--- a/brainsprite.js
+++ b/brainsprite.js
@@ -1,3 +1,8 @@
+function displayFloat (v, nbDecimals) {
+  var str = parseFloat(v).toFixed(nbDecimals)
+  return str.indexOf('.') === -1 ? str : str.replace(/0+$/, '')
+}
+
 function initBrain (params) {
   // Parameter initialization - for internal use
 
@@ -417,9 +422,7 @@ var brainsprite = function (params) {
 
         // Draw the value at current voxel
         if (brain.flagValue) {
-          let value = 'value = ' +
-            Number.parseFloat(brain.voxelValue).toPrecision(brain.nbDecimals)
-              .replace(/0+$/, '')
+          let value = isNaN(brain.voxelValue) ? 'no value' : 'value = ' + displayFloat(brain.voxelValue, brain.nbDecimals)
           brain.context.fillStyle = brain.colorFont
           brain.context.fillText(value, Math.round(brain.widthCanvas.X / 10),
             Math.round((brain.heightCanvas.max * brain.heightColorBar * 2) +
@@ -473,10 +476,8 @@ var brainsprite = function (params) {
             brain.heightColorBar / 2), Math.round(brain.widthCanvas.Y * 0.6),
             Math.round(brain.heightCanvas.max * brain.heightColorBar))
           brain.context.fillStyle = brain.colorFont
-          let labelMin = Number.parseFloat(brain.colorMap.min).toPrecision(
-            brain.nbDecimals).replace(/0+$/, '')
-          let labelMax = Number.parseFloat(brain.colorMap.max).toPrecision(
-            brain.nbDecimals).replace(/0+$/, '')
+          let labelMin = displayFloat(brain.colorMap.min, brain.nbDecimals)
+          let labelMax = displayFloat(brain.colorMap.max, brain.nbDecimals)
           brain.context.fillText(labelMin, brain.widthCanvas.X +
             (brain.widthCanvas.Y * 0.2) -
             brain.context.measureText(labelMin).width / 2,

--- a/brainsprite.js
+++ b/brainsprite.js
@@ -422,7 +422,7 @@ var brainsprite = function (params) {
 
         // Draw the value at current voxel
         if (brain.flagValue) {
-          let value = isNaN(brain.voxelValue) ? 'no value' : 'value = ' + displayFloat(brain.voxelValue, brain.nbDecimals)
+          const value = isNaN(brain.voxelValue) ? 'no value' : 'value = ' + displayFloat(brain.voxelValue, brain.nbDecimals)
           brain.context.fillStyle = brain.colorFont
           brain.context.fillText(value, Math.round(brain.widthCanvas.X / 10),
             Math.round((brain.heightCanvas.max * brain.heightColorBar * 2) +
@@ -476,8 +476,8 @@ var brainsprite = function (params) {
             brain.heightColorBar / 2), Math.round(brain.widthCanvas.Y * 0.6),
             Math.round(brain.heightCanvas.max * brain.heightColorBar))
           brain.context.fillStyle = brain.colorFont
-          let labelMin = displayFloat(brain.colorMap.min, brain.nbDecimals)
-          let labelMax = displayFloat(brain.colorMap.max, brain.nbDecimals)
+          const labelMin = displayFloat(brain.colorMap.min, brain.nbDecimals)
+          const labelMax = displayFloat(brain.colorMap.max, brain.nbDecimals)
           brain.context.fillText(labelMin, brain.widthCanvas.X +
             (brain.widthCanvas.Y * 0.2) -
             brain.context.measureText(labelMin).width / 2,


### PR DESCRIPTION
Fix for https://github.com/brainsprite/brainsprite/issues/74

**Behaviour of the previous method**

100 with 0 decimals : not possible as toPrecision only accepts a number of decimals between 1 and 100
100 with 2 decimals : 1.0e+2
250 with 3 decimals : 25
0.0000001 with 10 decimals : 1.000000000e-7

**Behaviour of the new method**

100 with 0 decimals : 100. (the dot is explicitly added for consistency)
100 with 2 decimals : 100.
250 with 3 decimals : 250.
0.0000001 with 10 decimals : 0.00001

Edit: the display of the voxelValue was also modified to display "no value" instead of "value = NaN" when there is no data in the overlay for the current position.